### PR TITLE
Correct mistakes in CDDL and add tests for CDDL

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,8 @@
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: gem install cddl
+      - run: ./cddl-verify

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,5 +4,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: gem install cddl
+      - run: sudo gem install cddl
       - run: ./cddl-verify

--- a/cddl-verify
+++ b/cddl-verify
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# This script verifies that all of the schemas in test/validateion.json are
+# valid against the CDDL rules in jtd.cddl.
+#
+# It's expected that whenever we want to make updates to the CDDL rules in the
+# specification language, we also update jtd.cddl to ensure that the test suite
+# is in agreement with the specification.
+
 set -e
 
 for s in $(jq -c 'values[] | .schema' tests/validation.json | sort | uniq); do

--- a/cddl-verify
+++ b/cddl-verify
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+for s in $(jq -c 'values[] | .schema' tests/validation.json | sort | uniq); do
+  echo "$s"
+  cddl jtd.cddl validate <(echo "$s")
+done

--- a/draft-ucarion-json-type-definition-xx.md
+++ b/draft-ucarion-json-type-definition-xx.md
@@ -214,43 +214,44 @@ described in this section.
 ;
 ; definitions are prohibited from appearing on non-root schemas.
 root-schema = {
+  ? definitions: { * tstr => { schema}},
   schema,
-  ? definitions: { * tstr => schema },
 }
 
 ; schema is the main CDDL rule defining a JTD schema.
 ;
 ; All JTD schemas are JSON objects taking on one of eight forms
 ; listed here.
-schema = empty /
-  ref /
-  type /
-  enum /
-  elements /
-  properties /
-  values /
-  discriminator
+schema = (
+  ref //
+  type //
+  enum //
+  elements //
+  properties //
+  values //
+  discriminator //
+  empty //
+)
 
 ; shared is a CDDL rule containing properties that all eight schema
 ; forms share.
-shared = {
+shared = (
+  ? metadata: { * tstr => any },
   ? nullable: bool,
-  ? metadata: { * tstr => * },
-}
+)
 
 ; empty describes the "empty" schema form.
-empty = { shared }
+empty = shared
 
 ; ref describes the "ref" schema form.
 ;
 ; There are additional constraints on this form that cannot be
 ; expressed in CDDL. Section 2.2.2 describes these additional
 ; constraints in detail.
-ref = { shared, ref: tstr }
+ref = ( ref: tstr, shared )
 
 ; type describes the "type" schema form.
-type = {
-  shared,
+type = (
   type: "boolean"
     / "float32"
     / "float64"
@@ -261,18 +262,19 @@ type = {
     / "int32"
     / "uint32"
     / "string"
-    / "timestamp"
-}
+    / "timestamp",
+  shared,
+)
 
 ; enum describes the "enum" schema form.
 ;
 ; There are additional constraints on this form that cannot be
 ; expressed in CDDL. Section 2.2.4 describes these additional
 ; constraints in detail.
-enum = { shared, enum: [+ tstr] }
+enum = ( enum: [+ tstr], shared )
 
 ; elements describes the "elements" schema form.
-elements = { shared, elements: schema }
+elements = ( elements: { schema }, shared )
 
 ; properties describes the "properties" schema form.
 ;
@@ -283,39 +285,38 @@ elements = { shared, elements: schema }
 ; There are additional constraints on this form that cannot be
 ; expressed in CDDL. Section 2.2.6 describes these additional
 ; constraints in detail.
-properties = with-properties / with-optional-properties
+properties = (with-properties // with-optional-properties)
 
-with-properties = {
-  shared,
-  properties: { * tstr => schema },
-  ? optionalProperties: { * tstr => schema },
+with-properties = (
+  properties: { * tstr => { schema }},
+  ? optionalProperties: { * tstr => { schema }},
   ? additionalProperties: bool,
-}
+  shared,
+)
 
-with-optional-properties = {
-  shared,
-  ? properties: { * tstr => schema },
-  optionalProperties: { * tstr => schema },
+with-optional-properties = (
+  ? properties: { * tstr => { schema }},
+  optionalProperties: { * tstr => { schema }},
   ? additionalProperties: bool,
-}
+  shared,
+)
 
 ; values describes the "values" schema form.
-values = { shared, values: schema }
+values = ( values: { schema }, shared )
 
 ; discriminator describes the "discriminator" schema form.
 ;
 ; There are additional constraints on this form that cannot be
 ; expressed in CDDL. Section 2.2.8 describes these additional
 ; constraints in detail.
-discriminator = {
-  shared,
+discriminator = (
   discriminator: tstr,
 
   ; Note well: this rule is defined in terms of the "properties"
   ; CDDL rule, not the "schema" CDDL rule.
-  mapping: { * tstr => properties }
-}
-~~~
+  mapping: { * tstr => { properties } }
+  shared,
+)
 {: #cddl-schema title="CDDL definition of a schema"}
 
 The remainder of this section will describe constraints on JTD schemas which

--- a/jtd.cddl
+++ b/jtd.cddl
@@ -1,0 +1,108 @@
+; root-schema is identical to schema, but additionally allows for
+; definitions.
+;
+; definitions are prohibited from appearing on non-root schemas.
+root-schema = {
+  ? definitions: { * tstr => { schema}},
+  schema,
+}
+
+; schema is the main CDDL rule defining a JTD schema.
+;
+; All JTD schemas are JSON objects taking on one of eight forms
+; listed here.
+schema = (
+  ref //
+  type //
+  enum //
+  elements //
+  properties //
+  values //
+  discriminator //
+  empty //
+)
+
+; shared is a CDDL rule containing properties that all eight schema
+; forms share.
+shared = (
+  ? metadata: { * tstr => any },
+  ? nullable: bool,
+)
+
+; empty describes the "empty" schema form.
+empty = shared
+
+; ref describes the "ref" schema form.
+;
+; There are additional constraints on this form that cannot be
+; expressed in CDDL. Section 2.2.2 describes these additional
+; constraints in detail.
+ref = ( ref: tstr, shared )
+
+; type describes the "type" schema form.
+type = (
+  type: "boolean"
+    / "float32"
+    / "float64"
+    / "int8"
+    / "uint8"
+    / "int16"
+    / "uint16"
+    / "int32"
+    / "uint32"
+    / "string"
+    / "timestamp",
+  shared,
+)
+
+; enum describes the "enum" schema form.
+;
+; There are additional constraints on this form that cannot be
+; expressed in CDDL. Section 2.2.4 describes these additional
+; constraints in detail.
+enum = ( enum: [+ tstr], shared )
+
+; elements describes the "elements" schema form.
+elements = ( elements: { schema }, shared )
+
+; properties describes the "properties" schema form.
+;
+; This CDDL rule is defined so that a schema of the "properties" form
+; may omit a member named "properties" or a member named
+; "optionalProperties", but not both.
+;
+; There are additional constraints on this form that cannot be
+; expressed in CDDL. Section 2.2.6 describes these additional
+; constraints in detail.
+properties = (with-properties // with-optional-properties)
+
+with-properties = (
+  properties: { * tstr => { schema }},
+  ? optionalProperties: { * tstr => { schema }},
+  ? additionalProperties: bool,
+  shared,
+)
+
+with-optional-properties = (
+  ? properties: { * tstr => { schema }},
+  optionalProperties: { * tstr => { schema }},
+  ? additionalProperties: bool,
+  shared,
+)
+
+; values describes the "values" schema form.
+values = ( values: { schema }, shared )
+
+; discriminator describes the "discriminator" schema form.
+;
+; There are additional constraints on this form that cannot be
+; expressed in CDDL. Section 2.2.8 describes these additional
+; constraints in detail.
+discriminator = (
+  discriminator: tstr,
+
+  ; Note well: this rule is defined in terms of the "properties"
+  ; CDDL rule, not the "schema" CDDL rule.
+  mapping: { * tstr => { properties } }
+  shared,
+)


### PR DESCRIPTION
In reviewing the current draft of JSON Typedef, @cabo noticed mistakes in the CDDL definitions in the specification.

This PR tries to fix both the immediate problem (mistakes in the CDDL) and the broader problem (nothing really stops such mistakes again in the future). It does so by:

1. Updating the CDDL definitions in the specification language, and
2. Keeping a second copy of the CDDL definitions in `jtd.cddl`. A GitHub workflow will make sure that every example in the test suite is also a valid instance against `jtd.cddl`.