### PR TITLE
Fix typo in cddl-verify

### DIFF
--- a/cddl-verify
+++ b/cddl-verify
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This script verifies that all of the schemas in test/validateion.json are
+# This script verifies that all of the schemas in test/validation.json are
 # valid against the CDDL rules in jtd.cddl.
 #
 # It's expected that whenever we want to make updates to the CDDL rules in the


### PR DESCRIPTION
There's a spelling error in the comment in cddl-verify.