### PR TITLE
Add test case for undefined first optionalProperty

### DIFF
--- a/tests/validation.json
+++ b/tests/validation.json
@@ -3760,6 +3760,30 @@
     },
     "errors": []
   },
+  "strict optionalProperties - ok missing first optionalProperty": {
+      "schema": {
+        "optionalProperties": {
+          "foo": {"type": "string"},
+          "bar": {"type": "string"}
+        }
+      },
+      "instance": {
+        "bar": "bar"
+      },
+      "errors": []
+  },
+  "non-strict optionalProperties - ok no optionalProperty":{
+      "schema": {
+        "optionalProperties": {
+          "foo": {"type": "string"}
+        },
+        "additionalProperties": true
+      },
+      "instance": {
+        "bar": "bar"
+      },
+      "errors": []
+  },
   "strict optionalProperties - bad wrong type": {
     "schema": {
       "optionalProperties": {


### PR DESCRIPTION
These test cases address the special case of comma placement when serializing the first optional property. A comma must be placed before every optionalProperty except for the first one. This is an error-prone edge case because the first optionalProperty may not be defined. These tests trigger previously untested behavior for this edge case to prevent issues like ajv-validator/ajv#2181 or ajv-validator/ajv#2171.

Please advise if I can make any adjustments.